### PR TITLE
World load fix for storage bus.

### DIFF
--- a/src/main/java/extracells/part/PartFluidStorage.java
+++ b/src/main/java/extracells/part/PartFluidStorage.java
@@ -4,6 +4,8 @@ import appeng.api.AEApi;
 import appeng.api.networking.IGrid;
 import appeng.api.networking.events.MENetworkCellArrayUpdate;
 import appeng.api.networking.events.MENetworkStorageEvent;
+import appeng.api.networking.events.MENetworkChannelsChanged;
+import appeng.api.networking.events.MENetworkEventSubscribe;
 import appeng.api.parts.IPartCollsionHelper;
 import appeng.api.parts.IPartRenderHelper;
 import appeng.api.storage.ICellContainer;
@@ -198,5 +200,30 @@ public class PartFluidStorage extends PartECBase implements ICellContainer, IInv
         filterFluids[_index] = _fluid;
         handler.setPrioritizedFluids(filterFluids);
         sendInformation(_player);
+    }
+    
+    // Receive events for when the network channel changes
+    @MENetworkEventSubscribe
+    public void updateChannels( MENetworkChannelsChanged channel )
+    {
+        // Ensure we have a grid node.
+        if ( this.node != null )
+        {
+            // Is the grid node active?
+            boolean isNowActive = this.node.isActive();
+            
+            // Does our active level differ from the grid node?
+            if ( isNowActive != this.isActive )
+            {
+                // Set our active level to the same as the grid node.
+                this.isActive = isNowActive;
+                
+                // Fire the neighbor changed event.
+                this.onNeighborChanged();
+                
+                // Mark our host tile for an update.
+                this.host.markForUpdate();
+            }
+        }
     }
 }


### PR DESCRIPTION
**Issue:** The storage bus does not update the network on world load. The network must be changed in some way before storage buses report fluid contents.
This should correct the issue and allow the bus to report its containers contents as the network issues the channel changes.
