### PR TITLE
Change ME Fluid Craftingchamber name

### DIFF
--- a/src/main/resources/assets/extracells/lang/en_US.lang
+++ b/src/main/resources/assets/extracells/lang/en_US.lang
@@ -51,7 +51,7 @@ extracells.part.battery.name=ME Energy Cell Fixture
 //Blocks
 extracells.block.certustank=Certus Quartz Tank
 extracells.block.walrus.name=Walrus
-extracells.block.fluidcrafter.name=ME Fluid Craftingchamber
+extracells.block.fluidcrafter.name=ME Fluid Assembler
 
 //Tooltips and Chat-Messages
 extracells.tooltip.amount=Amount


### PR DESCRIPTION
Because ME Fluid Assembler sounds nicer (In my opinion). Although truth be told, I would have preferred Fluid Molecular Assembler. Wish it had the nice gimicky renders of the AE2 Molecular assembler though, this one looks more like from AE1 then AE2.
