### PR TITLE
Added simple AND-Expression Parser for OreDictExporter

### DIFF
--- a/src/main/scala/extracells/gui/GuiOreDictExport.java
+++ b/src/main/scala/extracells/gui/GuiOreDictExport.java
@@ -80,7 +80,7 @@ public class GuiOreDictExport extends GuiContainer {
 				this.guiLeft + this.xSize / 2 - 44, this.guiTop + 35, 88, 20,
 				StatCollector.translateToLocal("extracells.tooltip.save")));
 		this.searchbar = new GuiTextField(this.fontRendererObj, this.guiLeft
-				+ this.xSize / 2 - 44, this.guiTop + 20, 88, 10) {
+				+ this.xSize / 2 - 75, this.guiTop + 20, 150, 10) {
 
 			private int xPos = 0;
 			private int yPos = 0;
@@ -97,7 +97,7 @@ public class GuiOreDictExport extends GuiContainer {
 		};
 		this.searchbar.setEnableBackgroundDrawing(true);
 		this.searchbar.setFocused(true);
-		this.searchbar.setMaxStringLength(15);
+		this.searchbar.setMaxStringLength(128);
 		this.searchbar.setText(filter);
 	}
 

--- a/src/main/scala/extracells/part/PartOreDictExporter.java
+++ b/src/main/scala/extracells/part/PartOreDictExporter.java
@@ -16,6 +16,7 @@ import appeng.api.parts.IPartRenderHelper;
 import appeng.api.parts.PartItemStack;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.api.util.AEColor;
+import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import extracells.container.ContainerOreDictExport;
@@ -36,6 +37,7 @@ import net.minecraft.util.IIcon;
 import net.minecraft.util.StatCollector;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.oredict.OreDictionary;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
 
@@ -51,33 +53,79 @@ public class PartOreDictExporter extends PartECBase implements IGridTickable {
 	private boolean checkItem(IAEItemStack s) {
 		if (s == null || this.filter.equals(""))
 			return false;
+
 		int[] ids = OreDictionary.getOreIDs(s.getItemStack());
-		for (int id : ids) {
-			String name = OreDictionary.getOreName(id);
-			if (this.filter.startsWith("*") && this.filter.endsWith("*")) {
-				String filter2 = this.filter.replace("*", "");
-				if (filter2.equals(""))
-					return true;
-				if (name.contains(filter2))
-					return true;
-				continue;
-			} else if (this.filter.startsWith("*")) {
-				String filter2 = this.filter.replace("*", "");
-				if (name.endsWith(filter2))
-					return true;
-				continue;
-			} else if (this.filter.endsWith("*")) {
-				String filter2 = this.filter.replace("*", "");
-				if (name.startsWith(filter2))
-					return true;
-				continue;
+		GameRegistry.UniqueIdentifier identifier = GameRegistry.findUniqueIdentifierFor(s.getItem());
+
+		String[] filters = StringUtils.split(this.filter, '&');
+
+		boolean result = true;
+		for (String filter : filters) {
+			filter = filter.trim();
+
+			boolean exclude = filter.startsWith("!");
+			if (exclude) {
+				filter = filter.substring(1);
+			}
+
+			if (filter.startsWith("@")) {
+				filter = filter.substring(1);
+				if (!CheckFilter(exclude, filter, identifier.modId)) result = false;
+			} else if (filter.startsWith("~")) {
+				filter = filter.substring(1);
+				if (!CheckFilter(exclude, filter, identifier.name)) result = false;
 			} else {
-				if (name.equals(this.filter))
-					return true;
-				continue;
+				if (ids.length == 0) {
+					result = false;
+				} else {
+					boolean oreDictResult = true;
+					for (int id : ids) {
+						if (!CheckFilter(exclude, filter, OreDictionary.getOreName(id))) {
+							oreDictResult = false;
+						} else if (!exclude) {
+							oreDictResult = true;
+							break;
+						}
+					}
+
+					if (!oreDictResult) result = false;
+				}
 			}
 		}
-		return false;
+
+		return result;
+	}
+
+	private boolean CheckFilter(Boolean exclude, String filter, String name) {
+		if (filter.startsWith("*") && filter.endsWith("*")) {
+			filter = filter.replace("*", "");
+			if (filter.equals(""))
+				return true;
+
+			if (exclude && name.contains(filter))
+				return false;
+			if (!exclude && !name.contains(filter))
+				return false;
+		} else if (filter.startsWith("*")) {
+			filter = filter.replace("*", "");
+			if (exclude && name.endsWith(filter))
+				return false;
+			if (!exclude && !name.endsWith(filter))
+				return false;
+		} else if (filter.endsWith("*")) {
+			filter = filter.replace("*", "");
+			if (exclude && name.startsWith(filter))
+				return false;
+			if (!exclude && !name.startsWith(filter))
+				return false;
+		} else {
+			if (exclude && name.equals(filter))
+				return false;
+			if (!exclude && !name.equals(filter))
+				return false;
+		}
+
+		return true;
 	}
 
 	public boolean doWork(int rate, int TicksSinceLastCall) {


### PR DESCRIPTION
I tuned the OreDictExporter a little bit. 
You are now able to setup a simple AND-Expression in the TextBox.
Example:
ore* & !oreUranium & !@gibby_dungeons & !oreberry
will export all Ores, excluding Uranium, oreberrys and all ores from Arcana RPG (gibby_dungeons).
