### PR TITLE
fluid cells: reconcile storage math with AE2, other changes

### DIFF
--- a/src/main/scala/extracells/api/IHandlerStorageBase.java
+++ b/src/main/scala/extracells/api/IHandlerStorageBase.java
@@ -13,4 +13,6 @@ public interface IHandlerStorageBase {
 
     int usedTypes();
 
+    long storedCount();
+
 }

--- a/src/main/scala/extracells/inventory/cell/HandlerItemStorageGas.java
+++ b/src/main/scala/extracells/inventory/cell/HandlerItemStorageGas.java
@@ -247,7 +247,7 @@ public class HandlerItemStorageGas implements ICellInventoryHandler<IAEGasStack>
 
 	@Override
 	public int totalBytes() {
-		return this.totalBytes;
+		return this.totalBytes / 250; // HACK HACK HACK pending rework
 	}
 
 	@Override
@@ -257,7 +257,7 @@ public class HandlerItemStorageGas implements ICellInventoryHandler<IAEGasStack>
 
 	@Override
 	public int usedBytes() {
-		return this.totalBytes - freeBytes();
+		return (this.totalBytes - freeBytes()) / 250; // HACK HACK HACK pending rework
 	}
 
 	@Override
@@ -269,6 +269,11 @@ public class HandlerItemStorageGas implements ICellInventoryHandler<IAEGasStack>
 			}
 		}
 		return i;
+	}
+
+	@Override
+	public long storedCount() {
+		return this.totalBytes - freeBytes();
 	}
 
 	@Override
@@ -373,8 +378,7 @@ public class HandlerItemStorageGas implements ICellInventoryHandler<IAEGasStack>
 
 	@Override
 	public long getStoredItemCount() {
-		return 0;
-		//return this.
+		return this.storedCount();
 	}
 
 	@Override

--- a/src/main/scala/extracells/item/storage/ItemStorageCell.java
+++ b/src/main/scala/extracells/item/storage/ItemStorageCell.java
@@ -52,11 +52,12 @@ public abstract class ItemStorageCell extends ItemECBase implements ICellWorkben
 		IHandlerStorageBase cellHandler = (IHandlerStorageBase) handler;
 		boolean partitioned = cellHandler.isFormatted();
 		long usedBytes = cellHandler.usedBytes();
+		long storedCount = cellHandler.storedCount();
 
-		list.add(String.format(I18n.translateToLocal("extracells.tooltip.storage." + definition + ".bytes"), usedBytes / 250, cellHandler.totalBytes() / 250));
+		list.add(String.format(I18n.translateToLocal("extracells.tooltip.storage." + definition + ".bytes"), usedBytes, cellHandler.totalBytes()));
 		list.add(String.format(I18n.translateToLocal("extracells.tooltip.storage." + definition + ".types"), cellHandler.usedTypes(), cellHandler.totalTypes()));
-		if (usedBytes != 0) {
-			list.add(String.format(I18n.translateToLocal("extracells.tooltip.storage." + definition + ".content"), usedBytes));
+		if (storedCount != 0) {
+			list.add(String.format(I18n.translateToLocal("extracells.tooltip.storage." + definition + ".content"), storedCount));
 		}
 
 		if (partitioned) {

--- a/src/main/scala/extracells/item/storage/ItemStorageCellPortableFluid.scala
+++ b/src/main/scala/extracells/item/storage/ItemStorageCellPortableFluid.scala
@@ -44,11 +44,12 @@ object ItemStorageCellPortableFluid extends ItemECBase with IPortableFluidStorag
     val cellHandler: IHandlerFluidStorage = handler.asInstanceOf[IHandlerFluidStorage]
     val partitioned: Boolean = cellHandler.isFormatted
     val usedBytes: Long = cellHandler.usedBytes
+    val storedCount: Long = cellHandler.storedCount
     val aeCurrentPower: Double = getAECurrentPower(itemStack)
-    list2.add(String.format(I18n.translateToLocal("extracells.tooltip.storage.fluid.bytes"), (usedBytes / 250).asInstanceOf[AnyRef], (cellHandler.totalBytes / 250).asInstanceOf[AnyRef]))
+    list2.add(String.format(I18n.translateToLocal("extracells.tooltip.storage.fluid.bytes"), (usedBytes).asInstanceOf[AnyRef], (cellHandler.totalBytes).asInstanceOf[AnyRef]))
     list2.add(String.format(I18n.translateToLocal("extracells.tooltip.storage.fluid.types"), cellHandler.usedTypes.asInstanceOf[AnyRef], cellHandler.totalTypes.asInstanceOf[AnyRef]))
-    if (usedBytes != 0) {
-      list2.add(String.format(I18n.translateToLocal("extracells.tooltip.storage.fluid.content"), usedBytes.asInstanceOf[AnyRef]))
+    if (storedCount != 0) {
+      list2.add(String.format(I18n.translateToLocal("extracells.tooltip.storage.fluid.content"), storedCount.asInstanceOf[AnyRef]))
     }
     if (partitioned) {
       list2.add(I18n.translateToLocal("gui.appliedenergistics2.Partitioned") + " - " + I18n.translateToLocal("gui.appliedenergistics2.Precise"))

--- a/src/main/scala/extracells/item/storage/ItemStorageCellPortableGas.scala
+++ b/src/main/scala/extracells/item/storage/ItemStorageCellPortableGas.scala
@@ -49,11 +49,12 @@ object ItemStorageCellPortableGas extends ItemECBase with IPortableGasStorageCel
     val cellHandler: IHandlerGasStorage = handler.asInstanceOf[IHandlerGasStorage]
     val partitioned: Boolean = cellHandler.isFormatted
     val usedBytes: Long = cellHandler.usedBytes
+    val storedCount: Long = cellHandler.storedCount
     val aeCurrentPower: Double = getAECurrentPower(itemStack)
-    list2.add(String.format(I18n.translateToLocal("extracells.tooltip.storage.gas.bytes"), (usedBytes / 250).asInstanceOf[AnyRef], (cellHandler.totalBytes / 250).asInstanceOf[AnyRef]))
+    list2.add(String.format(I18n.translateToLocal("extracells.tooltip.storage.gas.bytes"), (usedBytes).asInstanceOf[AnyRef], (cellHandler.totalBytes).asInstanceOf[AnyRef]))
     list2.add(String.format(I18n.translateToLocal("extracells.tooltip.storage.gas.types"), cellHandler.usedTypes.asInstanceOf[AnyRef], cellHandler.totalTypes.asInstanceOf[AnyRef]))
-    if (usedBytes != 0) {
-      list2.add(String.format(I18n.translateToLocal("extracells.tooltip.storage.gas.content"), usedBytes.asInstanceOf[AnyRef]))
+    if (storedCount != 0) {
+      list2.add(String.format(I18n.translateToLocal("extracells.tooltip.storage.gas.content"), storedCount.asInstanceOf[AnyRef]))
     }
     if (partitioned) {
       list2.add(I18n.translateToLocal("gui.appliedenergistics2.Partitioned") + " - " + I18n.translateToLocal("gui.appliedenergistics2.Precise"))


### PR DESCRIPTION
Fixes #628.

Current implementation of fluid cells uses a hardcoded 250/byte ratio, which
in general may not correspond with the actual itemsPerByte for the rest of
AE2. Additionally, bytes per type are ignored.

This change pulls the actual itemsPerByte from the underlying AE2 channel
type, and makes types consume bytes at the same ratio as in AE2.

As a side effect, some misuse of "bytes" as "items" was corrected for fluid
cells (reconciling these with the AE2 behaviour) to avoid an integer overflow.
Additionally, some changes are made to gas cells to avoid UI confusion, but
the underlying mechanics of these cells are untouched as they are outside
scope for the issue being addressed.