### PR TITLE
Do not register items when their mod is not available

### DIFF
--- a/src/main/scala/extracells/proxy/CommonProxy.java
+++ b/src/main/scala/extracells/proxy/CommonProxy.java
@@ -91,7 +91,9 @@ public class CommonProxy {
 
 	public void registerItems() {
 		for (ItemEnum current : ItemEnum.values()) {
-			registerItem(current.getItem());
+			if (current.shouldRegister()) {
+				registerItem(current.getItem());
+			}
 		}
 	}
 

--- a/src/main/scala/extracells/registries/ItemEnum.java
+++ b/src/main/scala/extracells/registries/ItemEnum.java
@@ -80,4 +80,8 @@ public enum ItemEnum {
 	public Integration.Mods getMod() {
 		return mod;
 	}
+
+	public boolean shouldRegister() {
+		return mod == null || mod.isEnabled();
+	}
 }


### PR DESCRIPTION
Don't register items if their corresponding mod is not installed

this fix following crash:

```
net.minecraftforge.fml.common.LoaderExceptionModCrash: Caught exception from BuildCraft Lib (buildcraftlib)
Caused by: java.lang.Error: Failed to create a page link for extracells:storage.gas class extracells.item.storage.ItemStorageCellGas ({id:"extracells:storage.gas",Count:1,Damage:0s})
    at buildcraft.lib.client.guide.entry.PageEntryItemStack.iterateAllDefault(PageEntryItemStack.java:61)
    at buildcraft.lib.client.guide.GuideManager.generateContentsPage(GuideManager.java:256)
    at buildcraft.lib.client.guide.GuideManager.reload0(GuideManager.java:175)
    at buildcraft.lib.client.guide.GuideManager.reload(GuideManager.java:120)
    at buildcraft.lib.client.guide.GuideManager.reload(GuideManager.java:111)
    at buildcraft.lib.client.guide.GuideManager.onRegistryReload(GuideManager.java:101)
    at buildcraft.lib.BCLibEventDist.onReloadFinish(BCLibEventDist.java:93)
    at net.minecraftforge.fml.common.eventhandler.ASMEventHandler_553_BCLibEventDist_onReloadFinish_FinishLoad.invoke(.dynamic)
    at net.minecraftforge.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:90)
    at net.minecraftforge.fml.common.eventhandler.EventBus.post(EventBus.java:182)
    at buildcraft.lib.script.ReloadableRegistryManager.reload(ReloadableRegistryManager.java:87)
    at buildcraft.lib.script.ReloadableRegistryManager.reloadAll(ReloadableRegistryManager.java:44)
    at buildcraft.lib.BCLib.postInit(BCLib.java:132)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
    at java.lang.reflect.Method.invoke(Unknown Source)
    at net.minecraftforge.fml.common.FMLModContainer.handleModStateEvent(FMLModContainer.java:624)
    at sun.reflect.GeneratedMethodAccessor9.invoke(Unknown Source)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
    at java.lang.reflect.Method.invoke(Unknown Source)
    at com.google.common.eventbus.Subscriber.invokeSubscriberMethod(Subscriber.java:91)
    at com.google.common.eventbus.Subscriber$SynchronizedSubscriber.invokeSubscriberMethod(Subscriber.java:150)
    at com.google.common.eventbus.Subscriber$1.run(Subscriber.java:76)
    at com.google.common.util.concurrent.MoreExecutors$DirectExecutor.execute(MoreExecutors.java:399)
    at com.google.common.eventbus.Subscriber.dispatchEvent(Subscriber.java:71)
    at com.google.common.eventbus.Dispatcher$PerThreadQueuedDispatcher.dispatch(Dispatcher.java:116)
    at com.google.common.eventbus.EventBus.post(EventBus.java:217)
    at net.minecraftforge.fml.common.LoadController.sendEventToModContainer(LoadController.java:219)
    at net.minecraftforge.fml.common.LoadController.propogateStateMessage(LoadController.java:197)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
    at java.lang.reflect.Method.invoke(Unknown Source)
    at com.google.common.eventbus.Subscriber.invokeSubscriberMethod(Subscriber.java:91)
    at com.google.common.eventbus.Subscriber$SynchronizedSubscriber.invokeSubscriberMethod(Subscriber.java:150)
    at com.google.common.eventbus.Subscriber$1.run(Subscriber.java:76)
    at com.google.common.util.concurrent.MoreExecutors$DirectExecutor.execute(MoreExecutors.java:399)
    at com.google.common.eventbus.Subscriber.dispatchEvent(Subscriber.java:71)
    at com.google.common.eventbus.Dispatcher$PerThreadQueuedDispatcher.dispatch(Dispatcher.java:116)
    at com.google.common.eventbus.EventBus.post(EventBus.java:217)
    at net.minecraftforge.fml.common.LoadController.distributeStateMessage(LoadController.java:136)
    at net.minecraftforge.fml.common.Loader.initializeMods(Loader.java:749)
    at net.minecraftforge.fml.client.FMLClientHandler.finishMinecraftLoading(FMLClientHandler.java:336)
    at net.minecraft.client.Minecraft.init(Minecraft.java:535)
    at net.minecraft.client.Minecraft.run(Minecraft.java:3931)
    at net.minecraft.client.main.Main.main(SourceFile:123)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
    at java.lang.reflect.Method.invoke(Unknown Source)
    at net.minecraft.launchwrapper.Launch.launch(Launch.java:135)
    at net.minecraft.launchwrapper.Launch.main(Launch.java:28)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
    at java.lang.reflect.Method.invoke(Unknown Source)
    at org.multimc.onesix.OneSixLauncher.launchWithMainClass(OneSixLauncher.java:196)
    at org.multimc.onesix.OneSixLauncher.launch(OneSixLauncher.java:231)
    at org.multimc.EntryPoint.listen(EntryPoint.java:143)
    at org.multimc.EntryPoint.main(EntryPoint.java:34)
Caused by: java.lang.NullPointerException
    at appeng.me.storage.AbstractCellInventory.<init>(AbstractCellInventory.java:77)
    at appeng.me.storage.BasicCellInventory.<init>(BasicCellInventory.java:29)
    at appeng.me.storage.BasicCellInventory.createInventory(BasicCellInventory.java:58)
    at appeng.core.features.registries.cell.BasicCellHandler.getCellInventory(BasicCellHandler.java:46)
    at appeng.core.features.registries.cell.CellRegistry.getCellInventory(CellRegistry.java:108)
    at extracells.item.storage.ItemStorageCell.addInformation(ItemStorageCell.java:53)
    at net.minecraft.item.ItemStack.getTooltip(ItemStack.java:707)
    at buildcraft.lib.misc.GuiUtil.getFormattedTooltip(GuiUtil.java:432)
    at buildcraft.lib.client.guide.parts.contents.PageLinkItemStack.<init>(PageLinkItemStack.java:30)
    at buildcraft.lib.client.guide.entry.PageEntryItemStack.iterateAllDefault(PageEntryItemStack.java:58)
    ... 60 more
```

Cause of crash is that you register gas storage cell, but it's channel is null: https://github.com/ExtraCells/ExtraCells2/blob/rv6-1.12/src/main/scala/extracells/util/StorageChannels.scala#L16