### PR TITLE
Change GasStorageChannel to have the same UnitsPerByte as Liquids

### DIFF
--- a/src/main/scala/extracells/integration/mekanism/gas/GasStorageChannel.java
+++ b/src/main/scala/extracells/integration/mekanism/gas/GasStorageChannel.java
@@ -26,6 +26,12 @@ import net.minecraft.nbt.NBTTagCompound;
 
 public class GasStorageChannel implements IGasStorageChannel {
 
+    @Override
+    public int getUnitsPerByte()
+    {
+        return 8000;
+    }
+
     @Nonnull
     @Override
     public IItemList<IAEGasStack> createList() {


### PR DESCRIPTION
This fixes #680.

Default scaling is 8 (like for items), but a Unit of Liquid (and seemingly also for gas) is actally made up out of 1000 milliBuckets.